### PR TITLE
Fix collision system

### DIFF
--- a/Wizard_Duel.yyp
+++ b/Wizard_Duel.yyp
@@ -199,6 +199,14 @@
             }
         },
         {
+            "Key": "9b50771c-4023-4d46-b13c-add57847e6b9",
+            "Value": {
+                "id": "c516a984-d9f0-4f78-a7d3-55035e57a74b",
+                "resourcePath": "objects\\obj_solid\\obj_solid.yy",
+                "resourceType": "GMObject"
+            }
+        },
+        {
             "Key": "9cfdd533-d694-4597-8293-602d7d12f09c",
             "Value": {
                 "id": "381f8262-e0ea-41f7-8fd6-d5008be23765",

--- a/Wizard_Duel.yyp
+++ b/Wizard_Duel.yyp
@@ -71,6 +71,14 @@
             }
         },
         {
+            "Key": "18e58aca-ddcf-4472-bd2a-65b83114e87b",
+            "Value": {
+                "id": "2b707be8-33d3-42b4-98bb-5dcfe767da4a",
+                "resourcePath": "scripts\\resolve_colliders_y\\resolve_colliders_y.yy",
+                "resourceType": "GMScript"
+            }
+        },
+        {
             "Key": "1a6409e9-b41c-476f-9470-b768dedbe2a4",
             "Value": {
                 "id": "c22d32d6-b564-4e55-9a76-8fbd0b102467",
@@ -303,6 +311,14 @@
             }
         },
         {
+            "Key": "cf8d6a80-670d-41c0-9d56-e613d5828eee",
+            "Value": {
+                "id": "bb3e1acd-d917-4a28-930c-7c29d4f27b50",
+                "resourcePath": "scripts\\resolve_colliders_x\\resolve_colliders_x.yy",
+                "resourceType": "GMScript"
+            }
+        },
+        {
             "Key": "dd15d803-cec1-42a8-9ba4-811312c4c552",
             "Value": {
                 "id": "94c5971c-bfec-4471-9041-d7447183f619",
@@ -344,7 +360,8 @@
         }
     ],
     "script_order": [
-        
+        "18e58aca-ddcf-4472-bd2a-65b83114e87b",
+        "cf8d6a80-670d-41c0-9d56-e613d5828eee"
     ],
     "tutorial": ""
 }

--- a/datafiles/resolve_colliders_x.gml
+++ b/datafiles/resolve_colliders_x.gml
@@ -1,0 +1,45 @@
+/// resolve_colliders_x(sprite, hsp, colliders_list)
+//	Resolves the x axis collision with the colliders. ASSUMES ORIGIN IS TOP LEFT OF SPRITE.
+//		sprite		- The sprite to resolve. Uses the bounding box of the sprite
+//		hsp			- Horizontal speed of the sprite
+//		colliders_list  - The walls the sprite is touching
+//  Returns an array where
+//		index 0 - sprite's new x position
+//		index 1 - sprite's new x velocity
+var sprite = argument0;
+var x_disp = 0; // The amount to displace x by to resolve the wall collision.
+var hsp = argument1;
+var colliders_list = argument2;
+
+// How far to place the sprite from the wall
+// Needed to avoid weird roundoff error
+var COLLISION_TOLERANCE = 1;
+
+for (var i = 0; i < ds_list_size(colliders_list); i++) {
+	var collider = colliders_list[| i];
+	if place_meeting(sprite.x, sprite.y + x_disp, collider) {
+		if hsp > 0 {
+            // Sprite is moving to the right, so push it out to the left
+			var collider_left = collider.x;
+            // Note that all the bbox_ variables are ints, so we can't use them directly
+            // to get position, (.x and .y are real numbers!). Fortunately, masks dimension are
+            // always in pixels, so they should be ints.
+			var mask_width = sprite.bbox_right - sprite.bbox_left;
+			var sprite_right = sprite.x + mask_width;
+			x_disp += collider_left - sprite_right - COLLISION_TOLERANCE;
+		} else {
+            // Sprite is moving to the left, so push it out to the right
+			var collider_width = collider.bbox_right - collider.bbox_left;
+			var collider_right = collider.x + collider_width;
+			var sprite_left = sprite.x;
+			x_disp += collider_right - sprite_left + COLLISION_TOLERANCE;
+		}
+        // We hit a wall, so reset our hsp to zero.
+		hsp = 0.0;
+	}
+}
+
+var return_array;
+return_array[0] = x_disp;
+return_array[1] = hsp;
+return return_array;

--- a/datafiles/resolve_colliders_x.yy
+++ b/datafiles/resolve_colliders_x.yy
@@ -1,0 +1,8 @@
+{
+    "id": "cf8d6a80-670d-41c0-9d56-e613d5828eee",
+    "modelName": "GMScript",
+    "mvc": "1.0",
+    "name": "resolve_colliders_x",
+    "IsCompatibility": false,
+    "IsDnD": false
+}

--- a/datafiles_yy/resolve_colliders_x.gml.yy
+++ b/datafiles_yy/resolve_colliders_x.gml.yy
@@ -1,0 +1,19 @@
+{
+    "id": "67b12ecd-35e4-4ba5-834b-fa60907e5a78",
+    "modelName": "GMIncludedFile",
+    "mvc": "1.0",
+    "name": "resolve_colliders_x.gml",
+    "CopyToMask": -1,
+    "exists": false,
+    "exportAction": 0,
+    "exportDir": "",
+    "fileName": "resolve_colliders_x.gml",
+    "filePath": "datafiles",
+    "freeData": false,
+    "origName": "",
+    "overwrite": false,
+    "removeEnd": false,
+    "size": 0,
+    "store": false,
+    "tags": ""
+}

--- a/datafiles_yy/resolve_colliders_x.yy.yy
+++ b/datafiles_yy/resolve_colliders_x.yy.yy
@@ -1,0 +1,19 @@
+{
+    "id": "f7a9ed0f-8c83-4ad0-b070-079833589853",
+    "modelName": "GMIncludedFile",
+    "mvc": "1.0",
+    "name": "resolve_colliders_x.yy",
+    "CopyToMask": -1,
+    "exists": false,
+    "exportAction": 0,
+    "exportDir": "",
+    "fileName": "resolve_colliders_x.yy",
+    "filePath": "datafiles",
+    "freeData": false,
+    "origName": "",
+    "overwrite": false,
+    "removeEnd": false,
+    "size": 0,
+    "store": false,
+    "tags": ""
+}

--- a/objects/obj_platform/obj_platform.yy
+++ b/objects/obj_platform/obj_platform.yy
@@ -8,7 +8,7 @@
     ],
     "maskSpriteId": "00000000-0000-0000-0000-000000000000",
     "overriddenProperties": null,
-    "parentObjectId": "00000000-0000-0000-0000-000000000000",
+    "parentObjectId": "9b50771c-4023-4d46-b13c-add57847e6b9",
     "persistent": false,
     "physicsAngularDamping": 0.1,
     "physicsDensity": 0.5,
@@ -23,7 +23,7 @@
     "physicsShapePoints": null,
     "physicsStartAwake": true,
     "properties": null,
-    "solid": true,
+    "solid": false,
     "spriteId": "4bb7a8e2-14c4-4619-a07c-e90d1b6116dc",
     "visible": true
 }

--- a/objects/obj_player/Step_0.gml
+++ b/objects/obj_player/Step_0.gml
@@ -12,42 +12,40 @@ if(place_meeting(x, y + 1, obj_floor) || place_meeting(x, y + 1, obj_platform)){
 	vsp = key_jump * -jumpspeed;
 } //jumping
 
-hcollide = instance_place(x + hsp, y, obj_platform){
-	if(hcollide != noone){
-		yplus = 0;
-		while(place_meeting(x + hsp, y - yplus, obj_platform)){
-			yplus += 1;
-		}
-		if(place_meeting(x + hsp, y - yplus, obj_platform)){
-			while(!place_meeting(x + sign(hsp), y, obj_platform)){
-				x += sign(hsp);
-				hsp = 0;
-			}
-		}
-		else{
-			y -= 0.5*yplus;
-		}
-	}
-} //horizontal collisions
-// unsure how to fix: touching a platform instantly makes you go on top of it
+// COLLISION CODE
+// This code does the following things
+// 1. Move along y-axis
+// 2. Resolve y-axis collisions with walls
+// 3. Move along x-axis
+// 4. Resolve x-axis collisions with walls
 
-vcollide = instance_place(x, y + vsp, obj_platform);
-if(vcollide != noone){
-	if(sign(vsp) == 1){
-		if(!place_meeting(x, y, obj_platform)){
-			while(!place_meeting(x, y + sign(vsp), obj_platform)){
-				y += 1;
-				vsp = 0;
-			}
-		}
-	}
-} //vertical collisions
+// The list of colliders. This is a "DS list"
+colliders_list = ds_list_create();
 
-x += hsp;
+// 1. Move along y-axis
 y += vsp;
 
-x = clamp(x, 0, room_width);
-y = clamp(y, 0, room_height); //keeps player in room
+// 2. Resolve y-axis collisions with walls
+instance_place_list(x, y, obj_solid, colliders_list, false);
+resolve = resolve_colliders_y(self, vsp, colliders_list);
+y += resolve[0];
+vsp = resolve[1];
+
+// Clear the list and regenerate it (maybe we are not touching a collider
+// anymore since we just moved along the y-axis).
+ds_list_clear(colliders_list);
+
+// 3. Move along x-axis
+x += hsp;
+
+// 4. Resolve x-axis collisions with walls.
+instance_place_list(x, y, obj_solid, colliders_list, false);
+resolve = resolve_colliders_x(self, hsp, colliders_list);
+x += resolve[0];
+hsp = resolve[1];
+
+// Destroy the list to avoid leaking memory.
+ds_list_destroy(colliders_list);
 
 if(mana <= 10){
 	mana += 1/room_speed;

--- a/objects/obj_player1/KeyPress_82.gml
+++ b/objects/obj_player1/KeyPress_82.gml
@@ -1,13 +1,18 @@
+var SPRITE_V_CENTER = y + sprite_height / 2;
+var SPRITE_LEFT = x;
+var SPRITE_RIGHT = x + sprite_width;
 if(mana >= 1){
+    // Facing Left
 	if(move < 0){
-		with (instance_create_depth(x - 32, y, 0, obj_bullet1)){
+		with (instance_create_depth(SPRITE_LEFT, SPRITE_V_CENTER, 0, obj_bullet1)){
 			direction = 180;
 			originalPlayer = 1;
 		}
 		mana--;
 	}
+    // Facing Right
 	else{
-		with (instance_create_depth(x + 32, y, 0, obj_bullet1)){
+		with (instance_create_depth(SPRITE_RIGHT, SPRITE_V_CENTER, 0, obj_bullet1)){
 			direction = 0;
 			originalPlayer = 1;
 		}

--- a/objects/obj_player2/KeyPress_73.gml
+++ b/objects/obj_player2/KeyPress_73.gml
@@ -1,13 +1,18 @@
+var SPRITE_V_CENTER = y + sprite_height / 2;
+var SPRITE_LEFT = x;
+var SPRITE_RIGHT = x + sprite_width;
 if(mana >= 1){
+    // Facing left
 	if(move <= 0){
-		with (instance_create_depth(x - 32, y, 0, obj_bullet2)){
+		with (instance_create_depth(SPRITE_LEFT, SPRITE_V_CENTER, 0, obj_bullet2)){
 			direction = 180;
 			originalPlayer = 2;
 		}
 		mana--;
 	}
+    // Facing right
 	else{
-		with (instance_create_depth(x + 32, y, 0, obj_bullet2)){
+		with (instance_create_depth(SPRITE_RIGHT, SPRITE_V_CENTER, 0, obj_bullet2)){
 			direction = 0;
 			originalPlayer = 2;
 		}

--- a/objects/obj_solid/obj_solid.yy
+++ b/objects/obj_solid/obj_solid.yy
@@ -1,14 +1,14 @@
 {
-    "id": "76a2ebd4-db0f-46f2-bbb1-33ca7c4bcffb",
+    "id": "9b50771c-4023-4d46-b13c-add57847e6b9",
     "modelName": "GMObject",
     "mvc": "1.0",
-    "name": "obj_floor",
+    "name": "obj_solid",
     "eventList": [
         
     ],
     "maskSpriteId": "00000000-0000-0000-0000-000000000000",
     "overriddenProperties": null,
-    "parentObjectId": "9b50771c-4023-4d46-b13c-add57847e6b9",
+    "parentObjectId": "00000000-0000-0000-0000-000000000000",
     "persistent": false,
     "physicsAngularDamping": 0.1,
     "physicsDensity": 0.5,
@@ -24,6 +24,6 @@
     "physicsStartAwake": true,
     "properties": null,
     "solid": false,
-    "spriteId": "0229575a-09fa-4751-96fa-4c7baa7045f1",
+    "spriteId": "00000000-0000-0000-0000-000000000000",
     "visible": true
 }

--- a/scripts/resolve_colliders_x/resolve_colliders_x.gml
+++ b/scripts/resolve_colliders_x/resolve_colliders_x.gml
@@ -1,0 +1,45 @@
+/// resolve_colliders_x(sprite, hsp, colliders_list)
+//	Resolves the x axis collision with the colliders. ASSUMES ORIGIN IS TOP LEFT OF SPRITE.
+//		sprite		- The sprite to resolve. Uses the bounding box of the sprite
+//		hsp			- Horizontal speed of the sprite
+//		colliders_list  - The walls the sprite is touching
+//  Returns an array where
+//		index 0 - sprite's new x position
+//		index 1 - sprite's new x velocity
+var sprite = argument0;
+var x_disp = 0; // The amount to displace x by to resolve the wall collision.
+var hsp = argument1;
+var colliders_list = argument2;
+
+// How far to place the sprite from the wall
+// Needed to avoid weird roundoff error
+var COLLISION_TOLERANCE = 1;
+
+for (var i = 0; i < ds_list_size(colliders_list); i++) {
+	var collider = colliders_list[| i];
+	if place_meeting(sprite.x, sprite.y + x_disp, collider) {
+		if hsp > 0 {
+            // Sprite is moving to the right, so push it out to the left
+			var collider_left = collider.x;
+            // Note that all the bbox_ variables are ints, so we can't use them directly
+            // to get position, (.x and .y are real numbers!). Fortunately, masks dimension are
+            // always in pixels, so they should be ints.
+			var mask_width = sprite.bbox_right - sprite.bbox_left;
+			var sprite_right = sprite.x + mask_width;
+			x_disp += collider_left - sprite_right - COLLISION_TOLERANCE;
+		} else {
+            // Sprite is moving to the left, so push it out to the right
+			var collider_width = collider.bbox_right - collider.bbox_left;
+			var collider_right = collider.x + collider_width;
+			var sprite_left = sprite.x;
+			x_disp += collider_right - sprite_left + COLLISION_TOLERANCE;
+		}
+        // We hit a wall, so reset our hsp to zero.
+		hsp = 0.0;
+	}
+}
+
+var return_array;
+return_array[0] = x_disp;
+return_array[1] = hsp;
+return return_array;

--- a/scripts/resolve_colliders_x/resolve_colliders_x.yy
+++ b/scripts/resolve_colliders_x/resolve_colliders_x.yy
@@ -1,0 +1,8 @@
+{
+    "id": "cf8d6a80-670d-41c0-9d56-e613d5828eee",
+    "modelName": "GMScript",
+    "mvc": "1.0",
+    "name": "resolve_colliders_x",
+    "IsCompatibility": false,
+    "IsDnD": false
+}

--- a/scripts/resolve_colliders_y/resolve_colliders_y.gml
+++ b/scripts/resolve_colliders_y/resolve_colliders_y.gml
@@ -1,0 +1,44 @@
+/// resolve_colliders(sprite, vsp, colliders_list)
+//	Resolves the y axis collision with the colliders. ASSUMES ORIGIN IS TOP LEFT OF SPRITE.
+//		sprite		- The sprite to resolve. Uses the bounding box of the sprite
+//		vsp			- Vertical speed of the sprite
+//		colliders_list  - The walls the sprite is touching
+//  Returns an array where
+//		index 0 - sprite's new y position
+//		index 1 - sprite's new y velocity
+var sprite = argument0;
+var y_disp = 0;
+var vsp = argument1;
+var colliders_list = argument2;
+
+// How far to place the sprite from the wall
+// Needed to avoid roundoff errors
+var COLLISION_TOLERANCE = 1;
+
+for (var i = 0; i < ds_list_size(colliders_list); i++) {
+	var collider = colliders_list[| i];
+	if place_meeting(sprite.x, sprite.y + y_disp, collider) {
+		if vsp > 0 {
+            // We are move **DOWN** so push the sprite up.
+			var collider_top = collider.y;
+            // Note that all the bbox_ variables are ints, so we can't use them directly
+            // to get position, (.x and .y are real numbers!). Fortunately, masks dimension are
+            // always in pixels, so they should be ints.
+            var mask_height = sprite.bbox_bottom - sprite.bbox_top;
+			var sprite_bottom = sprite.y + mask_height;
+			y_disp += collider_top - sprite_bottom - COLLISION_TOLERANCE;
+		} else {
+            // We are moving up, so push the sprite down.
+			var collider_height = collider.bbox_bottom - collider.bbox_top;
+			var collider_bottom = collider.y + collider_height;
+			var sprite_top = sprite.y;
+			y_disp += collider_bottom - sprite_top + COLLISION_TOLERANCE;
+		}
+		vsp = 0.0;
+	}
+}
+
+var return_array;
+return_array[0] = y_disp;
+return_array[1] = vsp;
+return return_array;

--- a/scripts/resolve_colliders_y/resolve_colliders_y.yy
+++ b/scripts/resolve_colliders_y/resolve_colliders_y.yy
@@ -1,0 +1,8 @@
+{
+    "id": "18e58aca-ddcf-4472-bd2a-65b83114e87b",
+    "modelName": "GMScript",
+    "mvc": "1.0",
+    "name": "resolve_colliders_y",
+    "IsCompatibility": false,
+    "IsDnD": false
+}

--- a/sprites/spr_floor/spr_floor.yy
+++ b/sprites/spr_floor/spr_floor.yy
@@ -54,7 +54,7 @@
             "visible": true
         }
     ],
-    "origin": 6,
+    "origin": 0,
     "originLocked": false,
     "playbackSpeed": 15,
     "playbackSpeedType": 0,
@@ -66,5 +66,5 @@
     "type": 0,
     "width": 480,
     "xorig": 0,
-    "yorig": 31
+    "yorig": 0
 }

--- a/sprites/spr_platform/spr_platform.yy
+++ b/sprites/spr_platform/spr_platform.yy
@@ -54,7 +54,7 @@
             "visible": true
         }
     ],
-    "origin": 6,
+    "origin": 0,
     "originLocked": false,
     "playbackSpeed": 15,
     "playbackSpeedType": 0,
@@ -66,5 +66,5 @@
     "type": 0,
     "width": 96,
     "xorig": 0,
-    "yorig": 3
+    "yorig": 0
 }

--- a/sprites/spr_player1/spr_player1.yy
+++ b/sprites/spr_player1/spr_player1.yy
@@ -54,7 +54,7 @@
             "visible": true
         }
     ],
-    "origin": 4,
+    "origin": 0,
     "originLocked": false,
     "playbackSpeed": 15,
     "playbackSpeedType": 0,
@@ -65,6 +65,6 @@
     "textureGroupId": "1225f6b0-ac20-43bd-a82e-be73fa0b6f4f",
     "type": 0,
     "width": 32,
-    "xorig": 16,
-    "yorig": 16
+    "xorig": 0,
+    "yorig": 0
 }

--- a/sprites/spr_player2/spr_player2.yy
+++ b/sprites/spr_player2/spr_player2.yy
@@ -54,7 +54,7 @@
             "visible": true
         }
     ],
-    "origin": 4,
+    "origin": 0,
     "originLocked": false,
     "playbackSpeed": 15,
     "playbackSpeedType": 0,
@@ -65,6 +65,6 @@
     "textureGroupId": "1225f6b0-ac20-43bd-a82e-be73fa0b6f4f",
     "type": 0,
     "width": 32,
-    "xorig": 16,
-    "yorig": 16
+    "xorig": 0,
+    "yorig": 0
 }

--- a/views/2ed345d6-8410-4b55-a076-06bec8456496.yy
+++ b/views/2ed345d6-8410-4b55-a076-06bec8456496.yy
@@ -13,7 +13,8 @@
         "f2f032b6-ad1a-43fc-a26f-2fa66f961c8a",
         "bbaf5e43-5e67-4ab1-9e70-22807a91f324",
         "75e541fe-4f9e-499d-9bbf-61ccf65581ef",
-        "40694ff2-d68c-47cd-b219-e148dabbc77e"
+        "40694ff2-d68c-47cd-b219-e148dabbc77e",
+        "9b50771c-4023-4d46-b13c-add57847e6b9"
     ],
     "filterType": "GMObject",
     "folderName": "objects",

--- a/views/889a8df9-e1c3-469c-bc01-38485eaeeb80.yy
+++ b/views/889a8df9-e1c3-469c-bc01-38485eaeeb80.yy
@@ -4,7 +4,8 @@
     "mvc": "1.1",
     "name": "889a8df9-e1c3-469c-bc01-38485eaeeb80",
     "children": [
-        
+        "18e58aca-ddcf-4472-bd2a-65b83114e87b",
+        "cf8d6a80-670d-41c0-9d56-e613d5828eee"
     ],
     "filterType": "GMScript",
     "folderName": "scripts",


### PR DESCRIPTION
This PR fixes the collision system. It makes the following changes

- Adds two scripts, `resolve_collision_x` and `resolve_collision_y`. These are scripts designed to take in a sprite, collider (aka: wall) and velocity, and returns the expected displacement and new velocity of that sprite.
- Changes origin of the player masks and platforms to the upper left. This is done because 1. This is a common thing to do in most game engines and 2. It makes the collision code easier to write.
- Refactors the bullet spawning locations slightly to compensate for origin changes
- Adds `obj_solid`, which is a helper object that `obj_platform` and `obj_floor` inherit from. It contains no actual code and is only used as a marker object that the object is in fact, a floor/wall thing.